### PR TITLE
Improve beginner guide and script compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,30 @@ Make sure you have the following installed:
 
 ---
 
-## 🚀 Quick Start
+## 🚀 Quick Start (Step-by-Step)
 
-Clone the repository:
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/yourusername/codex-laravel-dev-setup.git
+   cd codex-laravel-dev-setup
+   ```
 
-```bash
-git clone https://github.com/yourusername/codex-laravel-dev-setup.git
-cd codex-laravel-dev-setup
-```
+2. **Run the bootstrap script** – this installs Laravel, sets up a SQLite
+   database and prepares the `.env` file.
+   ```bash
+   chmod +x bootstrap.sh
+   ./bootstrap.sh
+   ```
 
-Run the bootstrap script:
+3. **Serve the application**
+   The setup script leaves you inside the new `codex-laravel` directory.
+   ```bash
+   php artisan serve
+   ```
+   Open `http://localhost:8000` in your browser.
 
-```bash
-chmod +x bootstrap.sh
-./bootstrap.sh
-```
-
-That’s it! Your Codex Laravel dev environment is ready.
+4. **Start coding!** All project files live inside the `codex-laravel`
+   directory.
 
 ---
 
@@ -76,6 +83,12 @@ A master script that runs `setup_environment.sh` inside `/scripts` and finalizes
 ### `scripts/setup_environment.sh`
 
 Automates Laravel install, environment config, database setup, key generation, and migration.
+
+### Next Steps for Beginners
+
+- Open the new `codex-laravel/.env` file to tweak configuration values.
+- Run additional migrations with `php artisan migrate` as you build out features.
+- Install packages using `composer require vendor/package`.
 
 ---
 

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -13,8 +13,16 @@ cp .env.example .env
 # Step 3: Setup SQLite
 mkdir -p database
 touch database/database.sqlite
-sed -i '' "s/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/" .env
-sed -i '' "s/DB_DATABASE=.*/DB_DATABASE=$(pwd | sed 's/\//\\\//g')\/database\/database.sqlite/" .env
+
+# Use the correct sed syntax for macOS or Linux
+DB_PATH="$(pwd)/database/database.sqlite"
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed -i '' "s/DB_CONNECTION=.*/DB_CONNECTION=sqlite/" .env
+  sed -i '' "s|DB_DATABASE=.*|DB_DATABASE=${DB_PATH}|" .env
+else
+  sed -i "s/DB_CONNECTION=.*/DB_CONNECTION=sqlite/" .env
+  sed -i "s|DB_DATABASE=.*|DB_DATABASE=${DB_PATH}|" .env
+fi
 
 # Step 4: Generate key
 php artisan key:generate


### PR DESCRIPTION
## Summary
- expand README with detailed step-by-step quick start
- add beginner friendly next steps
- update setup script for macOS/Linux sed compatibility
- clarify php artisan serve step and add DB path variable

## Testing
- `shellcheck scripts/setup_environment.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d8bcb4c1483239ec8fecd9fba6440